### PR TITLE
Doc/add swagger

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DB_USERNAME=your_username
+DB_PASSWORD=your_password
+DATABASE_URL=your_database_url

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/
+.env

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.2.0-SNAPSHOT</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>br.com.tinylink</groupId>
 	<artifactId>api</artifactId>
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>org.mariadb.jdbc</groupId>
 			<artifactId>mariadb-java-client</artifactId>
-			<version>2.7.3</version> 
+			<version>2.7.3</version>
 		</dependency>
 
 
@@ -61,7 +61,19 @@
 			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
-		
+
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.3.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.github.cdimascio</groupId>
+			<artifactId>java-dotenv</artifactId>
+			<version>5.2.2</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/api/src/main/java/br/com/tinylink/api/config/SwaggerConfig.java
+++ b/api/src/main/java/br/com/tinylink/api/config/SwaggerConfig.java
@@ -1,0 +1,16 @@
+package br.com.tinylink.api.config;
+
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public GroupedOpenApi publicApi() {
+        return GroupedOpenApi.builder()
+                .group("api") // Nome do grupo (pode ser customizado)
+                .packagesToScan("br.com.tinylink.api") // Pacote dos seus controllers
+                .build();
+    }
+}

--- a/api/src/main/java/br/com/tinylink/api/config/SwaggerConfig.java
+++ b/api/src/main/java/br/com/tinylink/api/config/SwaggerConfig.java
@@ -10,7 +10,7 @@ public class SwaggerConfig {
     public GroupedOpenApi publicApi() {
         return GroupedOpenApi.builder()
                 .group("api") 
-                .packagesToScan("br.com.tinylink.api") // Pacote dos seus controllers
+                .packagesToScan("br.com.tinylink.api.controllers")
                 .build();
     }
 }

--- a/api/src/main/java/br/com/tinylink/api/config/SwaggerConfig.java
+++ b/api/src/main/java/br/com/tinylink/api/config/SwaggerConfig.java
@@ -9,7 +9,7 @@ public class SwaggerConfig {
     @Bean
     public GroupedOpenApi publicApi() {
         return GroupedOpenApi.builder()
-                .group("api") // Nome do grupo (pode ser customizado)
+                .group("api") 
                 .packagesToScan("br.com.tinylink.api") // Pacote dos seus controllers
                 .build();
     }

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -1,4 +1,6 @@
+spring.config.import=optional:file:.env[.properties]
+
 spring.jpa.hibernate.ddl-auto=update
-spring.datasource.url = jdbc:postgresql://db-postgres:5432/tiny_link
-spring.datasource.username=postgres
-spring.datasource.password=2004
+spring.datasource.url=${DATABASE_URL}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}


### PR DESCRIPTION
**Adiciona documentação via Swagger e gestão de credenciais via `.env`**

Esta implementação resolve dois problemas críticos:

1. **Documentação automatizada da API**
    - Integra o SpringDoc OpenAPI para gerar documentação interativa em `/swagger-ui.html`.
    - Facilita a onboarding de novos desenvolvedores e teste dos endpoints.
2. **Gestão segura de credenciais**
    - Migra dados sensíveis (como conexão com banco) para arquivo `.env`, trazendo:
    ✅ **Flexibilidade**: Cada desenvolvedor pode definir suas próprias credenciais localmente.
    ✅ **Segurança**: Evita o versionamento de dados sensíveis no repositório.

**Impacto**:

- Melhora a manutenibilidade e segurança do projeto.
- Alinha-se com as boas práticas do Twelve-Factor App (configuração via environment variables).

**Como testar**:

1. Crie um arquivo `.env` baseado no `.env.example` .
2. Acesse `http://localhost:8080/swagger-ui.html` para validar a documentação.